### PR TITLE
Require python3.6.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ py_modules = markdown_code_blocks
 install_requires =
     mistune
     pygments
-python_requires = >=3.6
+python_requires = >=3.6.1
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
[python 3 statement - 3.6.0](https://github.com/asottile/scratch/wiki/python-3-statement#360)

(due to broken `NamedTuple` in 3.6.0)

Committed via https://github.com/asottile/all-repos