### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,12 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38]
+    toxenvs: [py37, py38, py39, py310]
     os: linux

--- a/markdown_code_blocks.py
+++ b/markdown_code_blocks.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import argparse
-from typing import Optional
 from typing import Sequence
-from typing import Type
 
 import mistune
 import pygments.formatters
@@ -10,7 +10,7 @@ import pygments.util
 
 
 class CodeRenderer(mistune.HTMLRenderer):
-    def block_code(self, code: str, info: Optional[str] = None) -> str:
+    def block_code(self, code: str, info: str | None = None) -> str:
         try:
             lexer = pygments.lexers.get_lexer_by_name(info, stripnl=False)
             cssclass = f'highlight {info}'
@@ -23,12 +23,12 @@ class CodeRenderer(mistune.HTMLRenderer):
 
 def highlight(
         doc: str,
-        Renderer: Type[mistune.HTMLRenderer] = CodeRenderer,
+        Renderer: type[mistune.HTMLRenderer] = CodeRenderer,
 ) -> str:
     return mistune.Markdown(Renderer())(doc)
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filename', default='/dev/stdin')
     args = parser.parse_args(argv)

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -26,7 +25,7 @@ py_modules = markdown_code_blocks
 install_requires =
     mistune>=2.0.0a5
     pygments
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/tests/markdown_code_blocks_test.py
+++ b/tests/markdown_code_blocks_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from markdown_code_blocks import CodeRenderer
 from markdown_code_blocks import highlight
 from markdown_code_blocks import main

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,pre-commit
+envlist = py37,py38,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos